### PR TITLE
Ease mobile menu transition

### DIFF
--- a/src/components/Menu.tsx
+++ b/src/components/Menu.tsx
@@ -36,8 +36,8 @@ const Menu: FunctionComponent = () => {
               </div>
               <div
                 className={
-                  'lg:flex flex-grow items-center' +
-                  (menuOpen ? ' flex' : ' hidden')
+                  'lg:flex lg:h-auto flex-grow items-center overflow-hidden transition-height duration-1000' +
+                  (menuOpen ? ' h-24' : ' h-0')
                 }
                 id="example-navbar-info"
               >

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -6,6 +6,9 @@ module.exports = {
     extend: {
       fontFamily: {
         'titillium-web': ['Titillium Web', 'sans-serif']
+      },
+      transitionProperty: {
+        'height': 'height'
       }
     }
   },


### PR DESCRIPTION
**Motivation**:
Ease hamburger menu transition.

**Solution**:
- Added height transition property in tailwind.config.js
- Used height and overflow hidden properties to ease the menu transition

**Issue**:
https://github.com/JasonFritsche/news-from-the-wormhole/issues/28

**Animation**:
![ease-menu-transition](https://user-images.githubusercontent.com/34499486/136674177-8740006f-576e-4875-88bc-88fa044194a5.gif)