### PR TITLE
Fix/header card style

### DIFF
--- a/src/components/AppError.tsx
+++ b/src/components/AppError.tsx
@@ -4,24 +4,14 @@ import astronautimg from '../../assets/404-astronaut.png'
 
 const AppError = () => {
   return (
-    <div className="flex overflow-auto flex-col items-center h-screen">
-      <Card>
-        <div className="flex flex-col flex-1 p-3">
-          <div className="flex flex-row flex-1 justify-center">
-            <h1 className="font-titillium-web text-2xl md:text-3xl lg:text-4xl font-bold text-center text-purple-900">
-              An error occurred, please try again later...
-            </h1>
-          </div>
-          <div className="flex flex-row flex-1 justify-center">
-            <img
-              className="object-contain lg:object-scale-down w-full h-96"
-              src={astronautimg}
-              alt="logo image"
-            />
-          </div>
-        </div>
-      </Card>
-    </div>
+    <React.Fragment>
+      <div className='z-40 p-4 mt-5 text-center'>
+          <h2 className="font-titillium-web text-lg text-white md:text-2xl lg:text-3xl leading-4">
+          An error occurred, please try again later...
+          </h2>
+          <hr className='h-1 w-24 bg-white mt-5 inline-block rounded-sm'/>
+      </div>
+    </React.Fragment>
   )
 }
 

--- a/src/components/Article.tsx
+++ b/src/components/Article.tsx
@@ -15,16 +15,16 @@ const Article: FunctionComponent<Props> = ({ article, type }) => {
     <Card>
       <div className="flex flex-1">
         <img
-          className="object-cover overflow-hidden rounded-tl-2xl rounded-bl-2xl"
+          className="object-cover h-full w-full overflow-hidden rounded-tl-2xl rounded-bl-2xl"
           src={article.imageUrl}
           alt="Article Image"
         />
       </div>
-      <div className="flex flex-col flex-1 justify-evenly p-3.5 min-w-0">
-        <h2 className="object-cover text-4xl font-extrabold text-gray-800">
+      <div className="flex flex-col flex-1 justify-start gap-12 p-3.5 min-w-0">
+        <h2 className="object-cover text-4xl font-extrabold text-blue-200">
           {article.title}
         </h2>
-        <p className="text-gray-600">{article.summary}</p>
+        <p className="text-gray-300">{article.summary}</p>
         <div className="flex justify-between">
           <div className="farticle-meta-label">
             <div>

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -6,8 +6,8 @@ interface Props {
 
 const Card: FunctionComponent<Props> = (props) => {
   return (
-    <div className="z-40 p-4 md:w-4/5 opacity-90 hover:opacity-100">
-      <div className="flex flex-col sm:flex-row flex-shrink bg-gray-300 rounded-2xl shadow-xl hover:shadow-md">
+    <div className="z-40 p-4 md:w-4/5">
+      <div className="flex flex-col bg-indigo-800/30 backdrop-blur-md backdrop-opacity-50 sm:flex-row flex-shrink rounded-2xl shadow-xl hover:shadow-md">
         {props.children}
       </div>
     </div>

--- a/src/components/FetchArticles.tsx
+++ b/src/components/FetchArticles.tsx
@@ -67,13 +67,15 @@ const FetchArticles: FunctionComponent<Props> = ({ articleType }) => {
   }
 
   if (error) {
-    return <AppError></AppError>
+    return <AppError />
   } 
   else {
     return (
       <>
         <div className="flex flex-col items-center">
-          <Card>{cardHeaderContents(articleType)}</Card>
+        {/* <Card> */}
+        <Header articleType={articleType} />
+        {/* </Card> */}
           {content()}
         </div>
         {!isLoaded && (<div className="flex flex-row justify-center mt-0">

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -12,19 +12,18 @@ const Header: FunctionComponent<Props> = ({ articleType }) => {
     articleType === 'articles' ? articleAstronautImg : blogAstronautImg
   return (
     <React.Fragment>
-      <div className="flex flex-col flex-1 p-3">
-        <div className="flex flex-row flex-1 justify-center">
+      <div className='z-40 p-4 mt-5 text-center'>
+        {/* <div className="flex flex-row flex-1 justify-center">
           <img
-            className="object-contain lg:object-scale-down w-full h-96"
+            className="object-contain lg:object-scale-down w-full h-24"
             src={imgSource}
             alt="astronaut image"
           />
-        </div>
-        <div className="flex flex-row flex-1 justify-center">
-          <h2 className="font-titillium-web text-lg md:text-2xl lg:text-3xl leading-4 text-gray-700">
+        </div> */}
+          <h2 className="font-titillium-web text-lg text-white md:text-2xl lg:text-3xl leading-4">
             Read the latest space flight {title.toLowerCase()}.
           </h2>
-        </div>
+          <hr className='h-1 w-24 bg-white mt-5 inline-block rounded-sm'/>
       </div>
     </React.Fragment>
   )


### PR DESCRIPTION
PR for #27 
- remove header image and decrease font size.
<img width="1029" alt="Screenshot 2022-10-08 at 2 43 26 PM" src="https://user-images.githubusercontent.com/82387829/194699924-7455416b-1d86-4ec9-88de-eba9761d7f1d.png">

- make background of card transparent and blur.
- change text colour of cards.
<img width="1048" alt="Screenshot 2022-10-08 at 2 44 28 PM" src="https://user-images.githubusercontent.com/82387829/194699962-bed15d8f-56e3-4485-a68b-a5b7535accc1.png">
